### PR TITLE
Added render props

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,40 @@ https://github.com/nanot1m/react-foco/releases
 
 - `onClickOutside` — function called on clicks outside of wrapping nodes
 - `onFocusOutside` — function called on focus outside of wrapping nodes
-- `children` — children react elements
+- `render` — prop allows for inline rendering foco content
 - `className` — class passed to wrapping node
 - `style` — object with css properties passed to wrapping node
+- `children` — children react elements or function the same as prop `render`
+- `component` — component or tag which is used to render wrapper node
+
+### Render Props
+
+This prop are passed for callback in props render or children
+
+- `className?: string` — class name provided from Foco component
+- `style?: React.CSSProperties` — styles provided from Foco component
+- `onMouseDown: React.MouseEventHandler` — handler for checking clicks outside
+- `onFocus: React.FocusEventHandler` — handler for checking focuses outside
+- `onTouchStart: React.TouchEventHandler` — handler for checking touches outside
+
+### Render-prop example
+
+```jsx
+function MyComponent() {
+  return (
+    <Foco onClickOutside={() => alert('click out')}>
+      {wrapperProps => (
+        <div
+          {...wrapperProps}
+          style={{ border: '1px solid skyblue', textAlign: 'center' }}
+        >
+          <p>Hola! Clicks outside would trigger alerts</p>
+        </div>
+      )}
+    </Foco>
+  );
+}
+```
 
 ## Development
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,23 @@
 import React from 'react';
 
+export interface FocoRenderProps {
+  className?: string;
+  style?: React.CSSProperties;
+  onMouseDown: React.MouseEventHandler;
+  onFocus: React.FocusEventHandler;
+  onTouchStart: React.TouchEventHandler;
+}
+
+export type FocoRenderType = (props: FocoRenderProps) => React.ReactNode;
+
 export interface FocoProps {
   onClickOutside?: (event: MouseEvent | TouchEvent) => void;
   onFocusOutside?: (event: FocusEvent) => void;
-  children?: React.ReactNode;
+  children?: FocoRenderType | React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
+  component?: any;
+  render?: FocoRenderType;
 }
 
 export default class Foco extends React.Component<FocoProps> {
@@ -13,57 +25,72 @@ export default class Foco extends React.Component<FocoProps> {
   private focusCaptured: boolean = false;
 
   public componentDidMount() {
-    this.initDOMListeners();
+    this.init();
   }
 
   public componentWillUnmount() {
-    this.removeDOMListeners();
+    this.flush();
   }
 
   public render() {
-    return (
-      <span
-        className={this.props.className}
-        style={this.props.style}
-        onMouseDown={this.handleInnerClick}
-        onFocus={this.handleInnerFocus}
-        children={this.props.children}
-        onTouchStart={this.handleInnerClick}
-      />
+    const render = this.props.render || this.props.children;
+
+    if (typeof render === 'function') {
+      return render(this.getProps());
+    }
+
+    return this.renderComponent();
+  }
+
+  private renderComponent() {
+    return React.createElement(
+      this.props.component || 'span',
+      this.getProps(),
+      this.props.children
     );
   }
 
-  private initDOMListeners() {
-    document.addEventListener('mousedown', this.handleDocumentClick);
-    document.addEventListener('focus', this.handleDocumentFocus, true);
-    document.addEventListener('touchstart', this.handleDocumentClick);
+  private getProps(): FocoRenderProps {
+    return {
+      className: this.props.className,
+      style: this.props.style,
+      onMouseDown: this.innerClick,
+      onFocus: this.innerFocus,
+      onTouchStart: this.innerClick
+    };
   }
 
-  private removeDOMListeners() {
-    document.removeEventListener('mousedown', this.handleDocumentClick);
-    document.removeEventListener('focus', this.handleDocumentFocus);
-    document.removeEventListener('touchstart', this.handleDocumentClick);
+  private init() {
+    document.addEventListener('mousedown', this.documentClick);
+    document.addEventListener('focus', this.documentFocus, true);
+    document.addEventListener('touchstart', this.documentClick);
   }
 
-  private handleDocumentClick = (event: MouseEvent | TouchEvent) => {
+  private flush() {
+    document.removeEventListener('mousedown', this.documentClick);
+    document.removeEventListener('focus', this.documentFocus);
+    document.removeEventListener('touchstart', this.documentClick);
+  }
+
+  private documentClick = (event: MouseEvent | TouchEvent) => {
     if (!this.clickCaptured && this.props.onClickOutside) {
       this.props.onClickOutside(event);
     }
     this.clickCaptured = false;
   };
 
-  private handleInnerClick = () => {
+  private innerClick = () => {
     this.clickCaptured = true;
   };
 
-  private handleDocumentFocus = (event: FocusEvent) => {
+  private documentFocus = (event: FocusEvent) => {
     if (!this.focusCaptured && this.props.onFocusOutside) {
       this.props.onFocusOutside(event);
     }
     this.focusCaptured = false;
   };
 
-  private handleInnerFocus = () => {
+  private innerFocus = () => {
     this.focusCaptured = true;
   };
 }

--- a/stories/render-prop.stories.tsx
+++ b/stories/render-prop.stories.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+
+import { storiesOf } from '@storybook/react';
+
+import Foco from '../src';
+
+storiesOf('Render Prop', module)
+  .add('prop render', () => {
+    return (
+      <Foco
+        onClickOutside={() => alert('click out')}
+        render={wrapperProps => (
+          <div
+            {...wrapperProps}
+            style={{ border: '1px solid skyblue', textAlign: 'center' }}
+          >
+            <p>
+              Hola! Render prop is provided. Clicks outside would trigger alerts
+            </p>
+          </div>
+        )}
+      />
+    );
+  })
+  .add('prop children', () => {
+    return (
+      <Foco onClickOutside={() => alert('click out')}>
+        {wrapperProps => (
+          <div
+            {...wrapperProps}
+            style={{ border: '1px solid skyblue', textAlign: 'center' }}
+          >
+            <p>
+              Hola! Function as children prop is provided. Clicks outside would
+              trigger alerts
+            </p>
+          </div>
+        )}
+      </Foco>
+    );
+  })
+  .add('prop component', () => {
+    return (
+      <Foco
+        onClickOutside={() => alert('click out')}
+        component="div"
+        style={{ border: '1px solid skyblue', textAlign: 'center' }}
+      >
+        <p>
+          Hola! Component prop is provided. Clicks outside would trigger alerts
+        </p>
+      </Foco>
+    );
+  });


### PR DESCRIPTION
This PR adds the way to customize wrapper node.
There are 3 options:
- `component` prop — use if you need just to replace tag
- `render` prop — use if you need full control of output
- callback in `children` prop — the same as `render` prop

Here is the example of using callback in `children` prop

```jsx
function MyComponent() {
  return (
    <Foco onClickOutside={() => alert("click out")}>
      {wrapperProps => (
        <div
          {...wrapperProps}
          style={{ border: "1px solid skyblue", textAlign: "center" }}
        >
          <p>
            Hola! Clicks outside would
            trigger alerts
          </p>
        </div>
      )}
    </Foco>
  );
}
```

Fixes #2 