### PR TITLE
fix: a proper removing event listener

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -68,7 +68,7 @@ export default class Foco extends React.Component<FocoProps> {
 
   private flush() {
     document.removeEventListener('mousedown', this.documentClick);
-    document.removeEventListener('focus', this.documentFocus);
+    document.removeEventListener('focus', this.documentFocus, true);
     document.removeEventListener('touchstart', this.documentClick);
   }
 


### PR DESCRIPTION
`removeEventListener` must be called with the same arguments as `addEventListener`, else an event listener won't be removed